### PR TITLE
SNAP-15259: Separate stress test loader pulumi build and stress testing

### DIFF
--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -22,7 +22,7 @@ on:
         required: true
     outputs:
       EC2_IP:
-        value: ${{ jobs.pulumi-set-up.outputs.TARGET_ACCOUNT }}
+        value: ${{ jobs.stress-test-pulumi-set-up.outputs.EC2_IP }}
       
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -43,7 +43,7 @@ jobs:
       contents: read
       packages: read
     outputs:
-      TARGET_ACCOUNT: ${{ steps.output_ec2_ip.outputs.TARGET_ACCOUNT }}
+      EC2_IP: ${{ steps.output_ec2_ip.outputs.EC2_IP }}
     steps:
       # workaround for the "fatal: detected dubious ownership in repository" error
       # this should be a github's problem

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -18,8 +18,6 @@ on:
         required: true
       TARGET_ACCOUNT:
         required: true
-      SSH_PRIVATE_KEY:
-        required: true
       CA_KEY:
         required: true
     outputs:

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -82,6 +82,5 @@ jobs:
     - name: output ec2 ip
       id: output_ec2_ip
       run: |
-        go run main.go stresstest.json /tmp/IP.json ${{ secrets.STRESS_TEST_TOTAL_TIME }}
-        echo "EC2_IP=$(cat /tmp/IP.json)" >> $GITHUB_OUTPUT
+        echo "EC2_IP=$(cat /tmp/IP.json | tr '\n' ' ')" >> $GITHUB_OUTPUT
       working-directory: ./stl

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -74,8 +74,8 @@ jobs:
         PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
         PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
         public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
-        regions: ${{ github.event.inputs.REGIONS }}
-        desired_capacity: ${{ github.event.inputs.DESIRED_CAPACITY }}
+        regions: ${{ inputs.REGIONS }}
+        desired_capacity: ${{ inputs.DESIRED_CAPACITY }}
         s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
         s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
 

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -25,7 +25,7 @@ on:
         value: ${{ jobs.stress-test-pulumi-set-up.outputs.EC2_IP }}
       
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: stl-${{ github.head_ref || github.run_id }}
 
 jobs:
   stress-test-pulumi-set-up:

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -1,0 +1,89 @@
+name: x (Reusable) Stress Test Loader Pulumi Set Up Workflow
+
+on:
+  workflow_call:
+    inputs:
+      REGIONS:
+        type: string
+        default: us-west-1, us-west-2
+      DESIRED_CAPACITY:
+        type: number
+        default: 2
+    secrets:
+      GITHUB_ACTION_PULUMI_ACCESS_TOKEN:
+        required: true
+      STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME:
+        required: true
+      STRESSTESTLOADER_S3_LOG_BUCKET_NAME:
+        required: true
+      TARGET_ACCOUNT:
+        required: true
+      SSH_PRIVATE_KEY:
+        required: true
+      CA_KEY:
+        required: true
+    outputs:
+      EC2_IP:
+        value: ${{ jobs.pulumi-set-up.outputs.TARGET_ACCOUNT }}
+      
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+
+jobs:
+  stress-test-pulumi-set-up:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/seconddinner/build:0.0.6
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    env:
+      SOURCE: ${{ github.ref_name }}
+    # These permissions are needed to interact with GitHub's OIDC Token endpoint.
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    outputs:
+      TARGET_ACCOUNT: ${{ steps.output_ec2_ip.outputs.TARGET_ACCOUNT }}
+    steps:
+      # workaround for the "fatal: detected dubious ownership in repository" error
+      # this should be a github's problem
+      # https://github.com/actions/runner-images/issues/6775
+    - name: Change Owner of Container Working Directory
+      run: chown root:root .
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        repository: seconddinner/stress-test-loader
+        path: stl
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.TARGET_ACCOUNT }}:role/githubaction-role
+        aws-region: us-west-2
+
+    - name: pulumi stress test infra
+      run: |
+        cd infra-pulumi/Infra.Pulumi/Infra.Pulumi
+        public_ip=$(curl -s https://ipinfo.io/ip)
+        export stress_test_loader_allowed_cidr="$public_ip/32"
+        dotnet run --project-name stress-test-loader-pulumi --stack-name stress
+      working-directory: ./stl
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
+        PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
+        public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
+        regions: ${{ github.event.inputs.REGIONS }}
+        desired_capacity: ${{ github.event.inputs.DESIRED_CAPACITY }}
+        s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
+        s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
+
+    - name: output ec2 ip
+      id: output_ec2_ip
+      run: |
+        go run main.go stresstest.json /tmp/IP.json ${{ secrets.STRESS_TEST_TOTAL_TIME }}
+        echo "EC2_IP=$(cat /tmp/IP.json)" >> $GITHUB_OUTPUT
+      working-directory: ./stl

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -82,5 +82,5 @@ jobs:
     - name: output ec2 ip
       id: output_ec2_ip
       run: |
-        echo "EC2_IP=$(cat /tmp/IP.json | tr '\n' ' ')" >> $GITHUB_OUTPUT
+        echo "EC2_IP=$(cat /tmp/IP.json | tr '\n' ' ' | sed 's/"/\\"/g')" >> $GITHUB_OUTPUT
       working-directory: ./stl

--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -23,9 +23,6 @@ on:
     outputs:
       EC2_IP:
         value: ${{ jobs.stress-test-pulumi-set-up.outputs.EC2_IP }}
-      
-concurrency:
-  group: stl-${{ github.head_ref || github.run_id }}
 
 jobs:
   stress-test-pulumi-set-up:

--- a/.github/workflows/_run-stress-test-loader.yaml
+++ b/.github/workflows/_run-stress-test-loader.yaml
@@ -97,7 +97,7 @@ jobs:
       working-directory: ./stl
 
     - name: get stress test result
-      if: ${{ github.event.inputs.GET_RESULTS == 'true' }}
+      if: ${{ inputs.GET_RESULTS }} == 'true'
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > id_ed25519
         chmod 600 id_ed25519

--- a/.github/workflows/_run-stress-test-loader.yaml
+++ b/.github/workflows/_run-stress-test-loader.yaml
@@ -93,6 +93,7 @@ jobs:
         cd stress-test-loader/client
         VERSION=$(git rev-parse --short HEAD)
         echo "${{ secrets.STRESS_TEST_JSON }}" > stresstest.json
+        aws s3 cp stresstest.json s3://${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}/stress-test-config-${{ github.run_id }}-${{ github.run_attempt }}.json
         go run main.go stresstest.json /tmp/IP.json ${{ secrets.STRESS_TEST_TOTAL_TIME }}
       working-directory: ./stl
 
@@ -122,7 +123,3 @@ jobs:
         stress_test_loader_allowed_cidr: "1.1.1.1/32" # dummy value
         s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
         s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
-
-    - name: delete stress test client exec in s3
-      run: |
-        aws s3 rm s3://${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}/${{ secrets.S3_KEY }}

--- a/.github/workflows/_run-stress-test-loader.yaml
+++ b/.github/workflows/_run-stress-test-loader.yaml
@@ -97,7 +97,7 @@ jobs:
       working-directory: ./stl
 
     - name: get stress test result
-      if: ${{ inputs.GET_RESULTS }} == 'true'
+      if: ${{ github.event.inputs.GET_RESULTS == 'true' }}
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > id_ed25519
         chmod 600 id_ed25519

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -83,7 +83,7 @@ jobs:
       run: |
         cd stress-test-loader/client
         VERSION=$(git rev-parse --short HEAD)
-        echo "${{ github.event.inputs.EC2_IP }}" > /tmp/IP.json
+        echo "${{ inputs.EC2_IP }}" > /tmp/IP.json
         echo "${{ secrets.STRESS_TEST_JSON }}" > stresstest.json
         aws s3 cp stresstest.json s3://${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}/stress-test-config-${{ github.run_id }}-${{ github.run_attempt }}.json
         go run main.go stresstest.json /tmp/IP.json ${{ secrets.STRESS_TEST_TOTAL_TIME }}
@@ -110,8 +110,8 @@ jobs:
         PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
         PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
         public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
-        regions: ${{ github.event.inputs.REGIONS }}
-        desired_capacity: ${{ github.event.inputs.DESIRED_CAPACITY }}
+        regions: ${{ inputs.REGIONS }}
+        desired_capacity: ${{ inputs.DESIRED_CAPACITY }}
         stress_test_loader_allowed_cidr: "1.1.1.1/32" # dummy value
         s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
         s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -89,7 +89,7 @@ jobs:
       working-directory: ./stl
 
     - name: get stress test result
-      if: ${{ github.event.inputs.GET_RESULTS == 'true' }}
+      if: ${{ inputs.GET_RESULTS == true }}
       run: |
         echo "${{ secrets.SSH_PRIVATE_KEY }}" > id_ed25519
         chmod 600 id_ed25519

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -82,7 +82,6 @@ jobs:
     - name: run stress test
       run: |
         cd stress-test-loader/client
-        VERSION=$(git rev-parse --short HEAD)
         echo "${{ inputs.EC2_IP }}" > /tmp/IP.json
         echo "${{ secrets.STRESS_TEST_JSON }}" > stresstest.json
         aws s3 cp stresstest.json s3://${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}/stress-test-config-${{ github.run_id }}-${{ github.run_attempt }}.json

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -32,9 +32,6 @@ on:
         required: true
       CA_KEY:
         required: true
-      
-concurrency:
-  group: stl-${{ github.head_ref || github.run_id }}
 
 jobs:
   stress-test:

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -34,7 +34,7 @@ on:
         required: true
       
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: stl-${{ github.head_ref || github.run_id }}
 
 jobs:
   stress-test:

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -69,6 +69,22 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::${{ secrets.TARGET_ACCOUNT }}:role/githubaction-role
         aws-region: us-west-2
+
+    - name: pulumi stress test infra (update allowed cidr)
+      run: |
+        cd infra-pulumi/Infra.Pulumi/Infra.Pulumi
+        public_ip=$(curl -s https://ipinfo.io/ip)
+        export stress_test_loader_allowed_cidr="$public_ip/32"
+        dotnet run --project-name stress-test-loader-pulumi --stack-name stress
+      working-directory: ./stl
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
+        PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
+        public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
+        regions: ${{ inputs.REGIONS }}
+        desired_capacity: ${{ inputs.DESIRED_CAPACITY }}
+        s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
+        s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
     
     - name: generate certs for ssl
       run: |

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -6,6 +6,15 @@ on:
       GET_RESULTS:
         type: boolean
         default: false
+      EC2_IP:
+        type: string
+        required: true
+      REGIONS:
+        type: string
+        default: us-west-1, us-west-2
+      DESIRED_CAPACITY:
+        type: number
+        default: 2
     secrets:
       GITHUB_ACTION_PULUMI_ACCESS_TOKEN:
         required: true
@@ -14,8 +23,6 @@ on:
       STRESSTESTLOADER_S3_LOG_BUCKET_NAME:
         required: true
       TARGET_ACCOUNT:
-        required: true
-      S3_KEY:
         required: true
       STRESS_TEST_JSON:
         required: true
@@ -72,26 +79,11 @@ jobs:
         bash gen_cert.sh
       working-directory: ./stl
 
-    - name: pulumi stress test infra
-      run: |
-        cd infra-pulumi/Infra.Pulumi/Infra.Pulumi
-        public_ip=$(curl -s https://ipinfo.io/ip)
-        export stress_test_loader_allowed_cidr="$public_ip/32"
-        dotnet run --project-name stress-test-loader-pulumi --stack-name stress
-      working-directory: ./stl
-      env:
-        PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
-        PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
-        public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
-        regions: us-west-1, us-west-2
-        desired_capacity: 2
-        s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
-        s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
-
     - name: run stress test
       run: |
         cd stress-test-loader/client
         VERSION=$(git rev-parse --short HEAD)
+        echo "${{ github.event.inputs.EC2_IP }}" > /tmp/IP.json
         echo "${{ secrets.STRESS_TEST_JSON }}" > stresstest.json
         aws s3 cp stresstest.json s3://${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}/stress-test-config-${{ github.run_id }}-${{ github.run_attempt }}.json
         go run main.go stresstest.json /tmp/IP.json ${{ secrets.STRESS_TEST_TOTAL_TIME }}
@@ -118,8 +110,8 @@ jobs:
         PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
         PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
         public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
-        regions: us-west-1, us-west-2
-        desired_capacity: 2
+        regions: ${{ github.event.inputs.REGIONS }}
+        desired_capacity: ${{ github.event.inputs.DESIRED_CAPACITY }}
         stress_test_loader_allowed_cidr: "1.1.1.1/32" # dummy value
         s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
         s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}

--- a/.github/workflows/_stress-test-packer-build.yaml
+++ b/.github/workflows/_stress-test-packer-build.yaml
@@ -8,9 +8,6 @@ on:
       CA_KEY:
         required: true
 
-concurrency:
-  group: stl-${{ github.head_ref || github.run_id }}
-
 jobs:
   packer-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/_stress-test-packer-build.yaml
+++ b/.github/workflows/_stress-test-packer-build.yaml
@@ -9,7 +9,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id }}
+  group: stl-${{ github.head_ref || github.run_id }}
 
 jobs:
   packer-build:


### PR DESCRIPTION
Split the original stress test loader workflow into two so that the first part is parallelizable with other workflows. This helps reduce workflow running time.