### PR TITLE
Make desired capacity string and destroy pulumi on failure

### DIFF
--- a/.github/workflows/_pulumi-set-up.yaml
+++ b/.github/workflows/_pulumi-set-up.yaml
@@ -7,8 +7,8 @@ on:
         type: string
         default: us-west-1, us-west-2
       DESIRED_CAPACITY:
-        type: number
-        default: 2
+        type: string
+        default: "2"
     secrets:
       GITHUB_ACTION_PULUMI_ACCESS_TOKEN:
         required: true
@@ -81,3 +81,20 @@ jobs:
       run: |
         echo "EC2_IP=$(cat /tmp/IP.json | tr '\n' ' ' | sed 's/"/\\"/g')" >> $GITHUB_OUTPUT
       working-directory: ./stl
+    
+    - name: pulumi destroy stress test infra
+      if: failure()
+      run: |
+        cd infra-pulumi/Infra.Pulumi/Infra.Pulumi
+        dotnet run --project-name stress-test-loader-pulumi --stack-name stress --destroy
+      working-directory: ./stl
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }} 
+        PULUMI_CONFIG_PASSPHRASE: ${{ secrets.GITHUB_ACTION_PULUMI_ACCESS_TOKEN }}
+        public_key: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH0qfb2vF40fmeIB8GGfkpjlpZVoVrRUQCe75yoNEO9a SD_STRESSTESTLOADER
+        regions: ${{ inputs.REGIONS }}
+        desired_capacity: ${{ inputs.DESIRED_CAPACITY }}
+        stress_test_loader_allowed_cidr: "1.1.1.1/32" # dummy value
+        s3_client_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_CLIENT_BUCKET_NAME }}
+        s3_log_bucket_name: ${{ secrets.STRESSTESTLOADER_S3_LOG_BUCKET_NAME }}
+

--- a/.github/workflows/_run-stress-test.yaml
+++ b/.github/workflows/_run-stress-test.yaml
@@ -13,8 +13,8 @@ on:
         type: string
         default: us-west-1, us-west-2
       DESIRED_CAPACITY:
-        type: number
-        default: 2
+        type: string
+        default: "2"
     secrets:
       GITHUB_ACTION_PULUMI_ACCESS_TOKEN:
         required: true


### PR DESCRIPTION
1. There are some problems with GitHub Actions input types when desired_capacity is of `number` type and we try to pass that parameter from the caller workflow. If we make this parameter a secret, it will make everything in the output containing this number a secret from the GitHub Actions' perspective, which prohibits the output of EC2 IPs.
2. When there is a failure to set up the infra, the infra is partially set. We should clean up the infra using pulumi destroy.